### PR TITLE
docs: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @michael-bowen-sc
+* @michael-bowen-sc @mattsahn @wchen-55e


### PR DESCRIPTION
Add Mike, Matt and Will as code owners of the repo as part of repo setup and branch protection.