### PR TITLE
docs(README): adding InGen repo + blog to profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,6 +22,7 @@ check out our KubeCon talk, "[Automatic Research Workflows at BlackRock](https:/
 * [EJML](https://ejml.org) - "[Open-sourcing a faster matrix calculation in Java](https://engineering.blackrock.com/open-sourcing-a-faster-matrix-calculation-in-java-a29fafd9d599)" (blog)
 * [SeparableOptimization.jl](https://github.com/JuliaFirstOrder/SeparableOptimization.jl) 
 * [PiecewiseQuadratics.jl](https://github.com/JuliaFirstOrder/PiecewiseQuadratics.jl) 
+* [InGen](https://github.com/blackrock/ingen) - "[Introducing InGen](https://engineering.blackrock.com/introducing-ingen-cb6a5083788c)" (blog)
 
 We are very excited to share more and are actively working on our open source initiatives. In the meantime, please learn more about what we do at [BlackRock](https://www.blackrock.com), read our [engineering blog](https://medium.com/blackrock-engineering), and take a look at [our careers site](https://careers.blackrock.com/life-at-blackrock-2/technology/) to learn more about our open roles!
 


### PR DESCRIPTION
I've added InGen to the profile page with a link to the repo + the launch blog.